### PR TITLE
Save generic Pulp 2 content info for futher migration steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,25 @@ $ sudo dnf install nfs-utils
 $ sudo mount <IP address of machine which exports /var/lib/pulp>:/var/lib/pulp /var/lib/pulp
 ```
 
+2. Configure your connection to MongoDB in /etc/pulp/settings.py. You can use the same configuration
+ as you have in Pulp 2 (only seeds might need to be different, it depends on your setup).
+ 
+E.g.
+```python
+PULP2_MONGODB = {
+    'name': 'pulp_database',
+    'seeds': '<your MongoDB bindIP>:27017',
+    'username': '',
+    'password': '',
+    'replica_set': '',
+    'ssl': False,
+    'ssl_keyfile': '',
+    'ssl_certfile': '',
+    'verify_ssl': True,
+    'ca_path': '/etc/pki/tls/certs/ca-bundle.crt',
+}
+```
+
 ### Installation
 
 Clone the repository and install it.
@@ -42,3 +61,54 @@ Clone the repository and install it.
 $ git clone https://github.com/pulp/pulp-2to3-migrate.git
 $ pip install -e pulp-2to3-migrate
 ```
+
+### User Guide
+
+All the commands should be run on Pulp 3 machine.
+
+1. Create a Migration Plan
+```
+$ # migrate content for Pulp 2 ISO plugin
+$ http POST :24817/pulp/api/v3/migration-plans/ plan='{ "plugins": [{"type": "iso", "content": 
+true}]}'
+
+HTTP/1.1 201 Created
+{
+    "_created": "2019-07-23T08:18:12.927007Z",
+    "_href": "/pulp/api/v3/migration-plans/59f8a786-c7d7-4e2b-ad07-701479d403c5/",
+    "plan": "{ \"plugins\": [{\"type\": \"iso\", \"content\": \ntrue}]}"
+}
+
+```
+
+2. Use the ``_href`` of the created Migration Plan to run the migration
+```
+$ http POST :24817/pulp/api/v3/migration-plans/59f8a786-c7d7-4e2b-ad07-701479d403c5/run/
+
+HTTP/1.1 202 Accepted
+{
+    "task": "/pulp/api/v3/tasks/55db2086-cf2e-438f-b5b7-cd0dbb7c8cf4/"
+}
+
+```
+
+### Plugin Writer's Guide
+
+If you are extending this migration tool to be able to migrate the content type of your interest
+from Pulp 2 to Pulp 3, here are some guidelines.
+
+1. Add the necessary mappings to the constants.py.
+ - to PULP2_SUPPORTED_PLUGINS
+ - to PULP_2TO3_MAP
+
+2. Add a Content model to communicate with Pulp 2.
+ - It has to have a field `type` which will correspond to the `_content_type_id` of your Content
+ in Pulp 2. Don't forget to add it to PULP_2TO3_MAP in step 1.
+ - It has to have a ForeignKey to the `pulp_2to3_migrate.app.models.Pulp2Content` model with the
+ `related_name` set to `'pulp3content'`
+
+3. Layout of the files/directories is important.
+ - Create a plugin directory in `pulp_2to3_migrate.pulp2` if it doesn't exist. Directory name
+  has to have the same name as you specified your plugin name in PULP2_SUPPORTED_PLUGINS in step 1.
+ - This directory has to have a module named `models.py` where you define you Content model to
+   for Pulp 2. Don't forget to put its name into PULP2_SUPPORTED_PLUGINS in step 1.

--- a/pulp_2to3_migrate/app/constants.py
+++ b/pulp_2to3_migrate/app/constants.py
@@ -1,2 +1,35 @@
 # for tasking system to ensure only one migration is run at a time
-PULP_2TO3_MIGRATION_RESOURCE = "pulp_2to3_migration"
+PULP_2TO3_MIGRATION_RESOURCE = 'pulp_2to3_migration'
+
+# Pulp2 plugins and their content types which can be migrated
+# 'pulp2_plugin': 'pulp2 model class name'
+SUPPORTED_PULP2_PLUGINS = {
+    'iso': ['ISO'],
+    # 'rpm': [
+    #     'Distribution',
+    #     'Drpm',
+    #     'Erratum',
+    #     'Modulemd',
+    #     'ModulemdDefaults',
+    #     'PackageCategory',
+    #     'PackageEnvironment',
+    #     'PackageGroup',
+    #     'PackageLangpacks',
+    #     'Rpm',
+    #     'Srpm',
+    #     'YumRepoMetadataFile'],
+    # 'docker': [
+    #     'Blob',
+    #     'Image',
+    #     'Manifest',
+    #     'ManifestList',
+    #     'Tag'],
+}
+
+# Mapping Pulp 2 content type to Pulp 3 plugin and content type
+# 'pulp2 content type id' -> ('pulp3 plugin', 'pulp3 content type')
+PULP_2TO3_TYPE_MAP = {
+    'iso': ('file', 'file'),
+    # 'erratum': ('rpm', 'advisory'),
+    # 'rpm': ('rpm': 'package'),
+}

--- a/pulp_2to3_migrate/app/models.py
+++ b/pulp_2to3_migrate/app/models.py
@@ -4,4 +4,30 @@ from pulpcore.plugin.models import Model
 
 
 class MigrationPlan(Model):
+    """
+    Migration Plans that have been created and maybe even run.
+
+    Fields:
+        plan (models.TextField): The migration plan in the JSON format
+    """
     plan = models.TextField()
+
+
+class Pulp2Content(Model):
+    """
+    General info about Pulp 2 content.
+
+    Pulp3 plugin models should create a Foreign key to this model.
+
+    Fields:
+        pulp2_id (models.UUIDField): Content ID in Pulp 2
+        pulp2_content_type_id (models.CharField): Content type in Pulp 2
+        pulp2_last_updated (models.PositiveIntegerField): Content creation or update time in Pulp 2
+        pulp2_storage_path (models.TextField): Content storage path on Pulp 2 system
+        downloaded (models.BooleanField): Flag to identify if content is on a filesystem or not
+    """
+    pulp2_id = models.UUIDField()
+    pulp2_content_type_id = models.CharField(max_length=255)
+    pulp2_last_updated = models.PositiveIntegerField()
+    pulp2_storage_path = models.TextField()
+    downloaded = models.BooleanField(default=True)

--- a/pulp_2to3_migrate/app/tasks/migrate.py
+++ b/pulp_2to3_migrate/app/tasks/migrate.py
@@ -1,4 +1,16 @@
+import asyncio
+import importlib
+import logging
 import time
+
+from django.db.models import Max
+
+from pulp_2to3_migrate.app.constants import SUPPORTED_PULP2_PLUGINS
+from pulp_2to3_migrate.app.models import Pulp2Content
+from pulp_2to3_migrate.pulp2 import connection
+
+_logger = logging.getLogger(__name__)
+
 
 def migrate_from_pulp2(migration_plan_pk, dry_run=False):
     """
@@ -10,4 +22,91 @@ def migrate_from_pulp2(migration_plan_pk, dry_run=False):
         migration_plan_pk (str): The migration plan PK.
         dry_run (bool): If True, nothing is migrated, only validation happens.
     """
-    time.sleep(1)
+    if dry_run:
+        _logger.debug('Running in a dry-run mode.')
+        # TODO: Migration Plan validation
+        return
+
+    connection.initialize()
+
+    # TODO: Migration Plan parsing and validation
+    # For now, the list of plugins to migrate is hard-coded.
+    plugins_to_migrate = ['iso']
+
+    # import all pulp 2 content models
+    content_models = []
+    for plugin, model_names in SUPPORTED_PULP2_PLUGINS.items():
+        if plugin not in plugins_to_migrate:
+            continue
+        module_path = 'pulp_2to3_migrate.pulp2.{plugin}.models'.format(plugin=plugin)
+        module = importlib.import_module(module_path)
+        for content_model_name in model_names:
+            content_models.append(getattr(module, content_model_name))
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(migrate_content(content_models))
+    #loop.run_until_complete(migrate_repositories())
+    loop.close()
+
+
+async def migrate_content(content_models):
+    """
+    Coroutine to initiate content migration for each plugin.
+
+    Args:
+         content_models: List of Pulp 2 content models to migrate data for
+    """
+    migrators =[]
+    for model in content_models:
+        _logger.debug('Migrating generic info for {type} content'.format(type=model.type))
+        migrator.append(migrate_content_generic_info(model))
+
+    await asyncio.wait(migrators)
+
+    # schedule content migration (hard links or copy; plugin specific content creation)
+
+
+async def migrate_content_generic_info(content_model):
+    """
+    Coroutine to migrate generic info about any Pulp 2 content.
+
+    Args:
+        content_model: Pulp 2 model for content which is being migrated.
+    """
+    batch_size = 10000
+    content_type = content_model.type
+    pulp2_content = []
+
+    # the latest timestamp we have in the migration tool Pulp2Content table for this content type
+    content_qs = Pulp2Content.objects.filter(pulp2_content_type_id=content_type)
+    last_updated = content_qs.aggregate(Max('pulp2_last_updated'))['pulp2_last_updated__max'] or 0
+    _logger.debug('The latest migrated {type} content has {timestamp} timestamp.'.format(
+        type=content_type,
+        timestamp=last_updated))
+
+    # query only newly created/updated items
+    mongo_content_qs = content_model.objects(_last_updated__gte=last_updated)
+    total_content = mongo_content_qs.count()
+    _logger.debug('Total count for {type} content to migrate: {total}'.format(
+        type=content_type,
+        total=total_content))
+
+    for i, record in enumerate(mongo_content_qs.only('id',
+                                                     '_storage_path',
+                                                     '_last_updated',
+                                                     '_content_type_id',
+                                                     'downloaded').batch_size(batch_size)):
+        item = Pulp2Content(pulp2_id=record['id'],
+                            pulp2_content_type_id=record['_content_type_id'],
+                            pulp2_last_updated=record['_last_updated'],
+                            pulp2_storage_path=record['_storage_path'],
+                            downloaded=record['downloaded'])
+        _logger.debug('Add content item to the list to migrate: {item}'.format(item=item))
+        pulp2_content.append(item)
+
+        save_batch = (i and not (i+1)%batch_size or i == total_content-1)
+        if save_batch:
+            _logger.debug('Bulk save for generic content info, saved so far: {index}'.format(
+                index=i+1))
+            Pulp2Content.objects.bulk_create(pulp2_content, ignore_conflicts=True)
+            pulp2_content = []

--- a/pulp_2to3_migrate/pulp2/base.py
+++ b/pulp_2to3_migrate/pulp2/base.py
@@ -1,0 +1,39 @@
+from mongoengine import (
+    BooleanField,
+    DictField,
+    Document,
+    IntField,
+    StringField
+)
+
+
+class ContentUnit(Document):
+    """
+    The base class for all Pulp 2 content units.
+
+    All classes inheriting from this class must define a _content_type_id and unit_key_fields.
+
+    _content_type_id must be of type mongoengine.StringField and have a default value of the string
+    name of the content type.
+
+    unit_key_fields must be a tuple of strings, each of which is a valid field name of the subcalss.
+    """
+    id = StringField(primary_key=True)
+    pulp_user_metadata = DictField()
+    _last_updated = IntField(required=True)
+    _storage_path = StringField()
+
+    meta = {
+        'abstract': True,
+    }
+
+
+class FileContentUnit(ContentUnit):
+    """
+    A Pulp 2 content unit representing content that is of type *file*.
+    """
+    downloaded = BooleanField()
+
+    meta = {
+        'abstract': True,
+    }

--- a/pulp_2to3_migrate/pulp2/connection.py
+++ b/pulp_2to3_migrate/pulp2/connection.py
@@ -48,7 +48,6 @@ def initialize(name=None, seeds=None, max_pool_size=None, replica_set=None, max_
     :param max_timeout:   the maximum number of seconds to wait between
                           connection retries
     :type  max_timeout:   int
-    :raises RuntimeError: This Exception is raised if initialize is called more than once
     """
     global _CONNECTION, _DATABASE
 
@@ -58,8 +57,9 @@ def initialize(name=None, seeds=None, max_pool_size=None, replica_set=None, max_
     # Exception, we can ensure that only one database connection is established per process which
     # will help us to ensure that the connection does not get overridden later.
     if _CONNECTION or _DATABASE:
-        raise RuntimeError(_("The database is already initialized. It is an error to call this "
-                             "function a second time."))
+        _logger.warn(_("The database is already initialized. It should not be called more than "
+                       "once."))
+        return
     try:
         connection_kwargs = {}
 

--- a/pulp_2to3_migrate/pulp2/iso/models.py
+++ b/pulp_2to3_migrate/pulp2/iso/models.py
@@ -1,0 +1,28 @@
+from mongoengine import (
+    IntField,
+    StringField,
+)
+
+from pulp_2to3_migrate.pulp2.base import FileContentUnit
+
+class ISO(FileContentUnit):
+    """
+    A model for Pulp 2 ISO content type.
+
+    It will become a File content type in Pulp 3 world.
+    """
+    name = StringField(required=True)
+    checksum = StringField(required=True)
+    size = IntField(required=True)
+
+    _ns = StringField(default='units_iso')
+    _content_type_id = StringField(required=True, default='iso')
+
+    unit_key_fields = ('name', 'checksum', 'size')
+    unit_display_name = 'ISO'
+    unit_description = 'ISO'
+    type = 'iso'
+
+    meta = {
+        'collection': 'units_iso',
+    }


### PR DESCRIPTION
It tries to save only newly added units, Pulp 2 content which is
already known to the migraiton tool is not re-queried or re-saved.

closes #5083
https://pulp.plan.io/issues/5083