### PR TITLE
Problem: Pulp2Content can't be queried using REST API

### DIFF
--- a/pulp_2to3_migrate/app/serializers.py
+++ b/pulp_2to3_migrate/app/serializers.py
@@ -4,10 +4,11 @@ from rest_framework import serializers
 
 from pulpcore.plugin.serializers import (
     ModelSerializer,
+    DetailRelatedField,
     IdentityField
 )
 
-from .models import MigrationPlan
+from .models import MigrationPlan, Pulp2Content
 
 
 class MigrationPlanSerializer(ModelSerializer):
@@ -48,3 +49,23 @@ class MigrationPlanRunSerializer(serializers.Serializer):
         default=False,
         write_only=True
     )
+
+class Pulp2ContentSerializer(ModelSerializer):
+    """
+    A serializer for the Pulp2Content model
+    """
+    _href = IdentityField(
+        view_name='migration-plans-detail'
+    )
+    pulp2_id = serializers.CharField(max_length=255)
+    pulp2_content_type_id = serializers.CharField(max_length=255)
+    pulp2_last_updated = serializers.IntegerField()
+    pulp2_storage_path = serializers.CharField()
+    downloaded = serializers.BooleanField(default=True)
+    pulp3_content = DetailRelatedField(required=False, allow_null=True, queryset=Pulp2Content.objects.all())
+
+    class Meta:
+        fields = ModelSerializer.Meta.fields + ('pulp2_id', 'pulp2_content_type_id',
+                                                'pulp2_last_updated', 'pulp2_storage_path',
+                                                'downloaded', 'pulp3_content')
+        model = Pulp2Content


### PR DESCRIPTION
Solution: add REST API for Pulp2Content

This patch adds a ViewSet, a Filter, and a Serializer for Pulp2Content model. This enables REST API
users to retrieve a list of Pulp2Content as well as individual units. Lots of filters for filtering
are also available.

fixes: #5231
https://pulp.plan.io/issues/5231