### PR TITLE
Allow storage_path to be null for artifactless content.

### DIFF
--- a/pulp_2to3_migrate/app/models/content.py
+++ b/pulp_2to3_migrate/app/models/content.py
@@ -23,7 +23,7 @@ class Pulp2Content(Model):
     pulp2_id = models.CharField(max_length=255)
     pulp2_content_type_id = models.CharField(max_length=255)
     pulp2_last_updated = models.PositiveIntegerField()
-    pulp2_storage_path = models.TextField()
+    pulp2_storage_path = models.TextField(null=True)
     downloaded = models.BooleanField(default=True)
     pulp3_content = models.ForeignKey(Content, on_delete=models.SET_NULL, null=True)
 


### PR DESCRIPTION
closes #5480
https://pulp.plan.io/issues/5480